### PR TITLE
Nick/fix consistent function return types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,11 @@ Add bulk pre-processing for URLs in your pipeline (requires Spawning API Key)::
 
    >>> import datadiligence as dd
    >>> urls = ["https://www.example.com/art-123456789.jpg", "https://www.example.com/art-987654321.jpg"]
+   >>> dd.filter_allowed(urls=urls)
+    ["https://www.example.com/art-123456789.jpg"]
    >>> dd.is_allowed(urls=urls)
-   ["https://www.example.com/art-123456789.jpg"]
+    [True, False]
+
 
 Check HTTP responses in post-processing::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -59,12 +59,19 @@ This will also instantiate some default Evaluators for you to use. We can pass a
 the package directly to use one of these defaults::
 
     >>> urls = ['https://www.google.com', 'https://www.yahoo.com', 'https://www.bing.com']
-    >>> approved_urls = dd.is_allowed(urls=urls)
+    >>> approved_urls = dd.filter_allowed(urls=urls)
     >>> approved_urls
     ['https://www.google.com']
 
-The response is a list of the URLs that are allowed. In this case, only Google is allowed.
-You can then continue to use this list of approved URLs throughout the ML pipeline.
+The response is a list of the URLs that are allowed. Additionally,
+you can use ``is_allowed`` to return a list of boolean responses::
+
+    >>> urls = ['https://www.google.com', 'https://www.yahoo.com', 'https://www.bing.com']
+    >>> approved_urls = dd.is_allowed(urls=urls)
+    >>> approved_urls
+    [True, False, False]
+
+In both cases, only Google is allowed.
 
 If you're using `pyarrow` or `pandas`, you must first convert the urls to a python list::
 
@@ -73,14 +80,14 @@ If you're using `pyarrow` or `pandas`, you must first convert the urls to a pyth
     >>> urls = pa.array(['https://www.google.com', 'https://www.yahoo.com', 'https://www.bing.com'])
     >>> approved_urls = dd.is_allowed(urls=urls.to_pylist())
     >>> approved_urls
-    ['https://www.google.com']
+    [True]
 
     >>> # pandas example
     >>> import pandas as pd
     >>> urls = pd.Series(['https://www.google.com', 'https://www.yahoo.com', 'https://www.bing.com'])
     >>> approved_urls = dd.is_allowed(urls=urls.to_list())
     >>> approved_urls
-    ['https://www.google.com']
+    [True]
 
 Some rules require additional information or dependencies, such as API Keys in the case of Spawning (see below).
 If the required dependencies are not met, the related rule will NOT evaluate, and the response will be the same as if the rule was not included.
@@ -88,7 +95,7 @@ If the required dependencies are not met, the related rule will NOT evaluate, an
 For example, if the Spawning API Key is not set in your environment variables::
 
     >>> urls = ['https://www.google.com', 'https://www.yahoo.com', 'https://www.bing.com']
-    >>> approved_urls = dd.is_allowed(urls=urls)
+    >>> approved_urls = dd.filter_allowed(urls=urls)
     Spawning API key not found. Please set your API key to the environment variable SPAWNING_API_KEY
     >>> approved_urls
     ['https://www.google.com', 'https://www.yahoo.com', 'https://www.bing.com']

--- a/examples/http_headers.py
+++ b/examples/http_headers.py
@@ -3,4 +3,4 @@ import requests
 
 
 response = requests.get("https://www.google.com/image")
-is_allowed = dd.is_allowed("postprocess", headers=response.headers)
+is_allowed = dd.is_allowed(headers=response.headers)

--- a/examples/pre_and_post_processing.py
+++ b/examples/pre_and_post_processing.py
@@ -12,14 +12,14 @@ d = md.select(["url"]).to_pandas()
 urls = d.iloc[:, 0].to_list()
 
 # send through pre-process steps (only includes Spawning API currently)
-verified_urls = dd.is_allowed("preprocess", urls=urls)
+verified_urls = dd.filter_allowed(urls=urls)  # use dd.is_allowed to get a list of booleans instead
 
 # you'll probably be downloading these images in your pipeline, this is a placeholder for that
 for url in verified_urls:
     response = requests.get(url)
     if response.status_code == 200:
         # this is the only new code you need here
-        is_allowed = dd.is_allowed("postprocess", headers=response.headers)
+        is_allowed = dd.is_allowed(response=response)
         if not is_allowed:
             continue
 

--- a/examples/spawning_api.py
+++ b/examples/spawning_api.py
@@ -11,4 +11,4 @@ d = md.select(["url"]).to_pandas()
 urls = d.iloc[:, 0].to_list()
 
 # send through pre-process steps (only includes Spawning API currently)
-verified_urls = dd.is_allowed("preprocess", urls=urls)
+verified_urls = dd.filter_allowed(urls=urls)

--- a/src/datadiligence/__init__.py
+++ b/src/datadiligence/__init__.py
@@ -23,4 +23,4 @@ finally:
 from .evaluators import HttpEvaluator, PostprocessEvaluator, PreprocessEvaluator, Evaluator
 
 # bootstrap methods
-from .bootstrap import load_defaults, register_evaluator, is_allowed, get_evaluator, deregister_evaluator, list_evaluators
+from .bootstrap import load_defaults, register_evaluator, is_allowed, filter_allowed, get_evaluator, deregister_evaluator, list_evaluators

--- a/src/datadiligence/bootstrap.py
+++ b/src/datadiligence/bootstrap.py
@@ -12,8 +12,6 @@ def load_defaults(user_agent=None):
     """Load the default evaluators."""
     register_evaluator(PreprocessEvaluator(user_agent=user_agent), overwrite=True)
     register_evaluator(PostprocessEvaluator(user_agent=user_agent), overwrite=True)
-    register_evaluator(HttpEvaluator(user_agent=user_agent), overwrite=True)
-
 
 def list_evaluators():
     """List the evaluators."""
@@ -79,10 +77,8 @@ def is_allowed(name=None, **kwargs):
         # based on the kwargs
         if "urls" in kwargs:
             return bootstrap_dictionary["preprocess"].is_allowed(**kwargs)
-        elif "response" in kwargs or "headers" in kwargs:
+        elif "url" in kwargs or "response" in kwargs or "headers" in kwargs:
             return bootstrap_dictionary["postprocess"].is_allowed(**kwargs)
-        elif "url" in kwargs:
-            return bootstrap_dictionary["http"].is_allowed(**kwargs)
         else:
             raise DefaultEvaluatorNotFound(list(kwargs.keys()))
 

--- a/src/datadiligence/bootstrap.py
+++ b/src/datadiligence/bootstrap.py
@@ -3,7 +3,7 @@ functions to preload default evaluators and make accessible globally
 """
 
 from .exceptions import EvaluatorAlreadyRegistered, EvaluatorNotRegistered, NotEvaluator, DefaultEvaluatorNotFound
-from .evaluators import Evaluator, PreprocessEvaluator, PostprocessEvaluator, HttpEvaluator
+from .evaluators import Evaluator, PreprocessEvaluator, PostprocessEvaluator
 
 bootstrap_dictionary = {}
 
@@ -12,6 +12,7 @@ def load_defaults(user_agent=None):
     """Load the default evaluators."""
     register_evaluator(PreprocessEvaluator(user_agent=user_agent), overwrite=True)
     register_evaluator(PostprocessEvaluator(user_agent=user_agent), overwrite=True)
+
 
 def list_evaluators():
     """List the evaluators."""

--- a/src/datadiligence/bootstrap.py
+++ b/src/datadiligence/bootstrap.py
@@ -87,4 +87,25 @@ def is_allowed(name=None, **kwargs):
             raise DefaultEvaluatorNotFound(list(kwargs.keys()))
 
 
+def filter_allowed(name=None, **kwargs):
+    """
+    Filter a list of content.
+
+    Args:
+        name (str): The name of a specific evaluator.
+        **kwargs: Arbitrary keyword arguments to read args from.
+    """
+    if name is not None:
+        if name not in bootstrap_dictionary:
+            raise EvaluatorNotRegistered(name)
+        return bootstrap_dictionary[name].filter_allowed(**kwargs)
+    else:
+        # since we are preloading evaluators manually, we can check to see which one to call
+        # based on the kwargs
+        if "urls" in kwargs:
+            return bootstrap_dictionary["preprocess"].filter_allowed(**kwargs)
+        else:
+            raise DefaultEvaluatorNotFound(list(kwargs.keys()))
+
+
 load_defaults()

--- a/src/datadiligence/evaluators/base.py
+++ b/src/datadiligence/evaluators/base.py
@@ -31,3 +31,7 @@ class Evaluator:
             if rule.is_ready() and not rule.is_allowed(**kwargs):
                 return False
         return True
+
+    def filter_allowed(self, **kwargs):
+        """Filter a list of entries based on the rules in this evaluator."""
+        raise NotImplementedError

--- a/src/datadiligence/evaluators/http.py
+++ b/src/datadiligence/evaluators/http.py
@@ -3,25 +3,22 @@ This module contains the HttpEvaluator class.
 """
 
 from .base import Evaluator
-from ..rules import XRobotsTagHeader, SpawningAPI
+from ..rules import XRobotsTagHeader
 
 
 class HttpEvaluator(Evaluator):
     """
-    HTTP Evaluator class. Loads XRobotsTagHeader and SpawningAPI rules by default.
+    HTTP Evaluator class. Loads XRobotsTagHeader rule by default.
     """
     name = "http"
 
-    def __init__(self, user_agent=None, respect_robots=True, respect_spawning=True):
+    def __init__(self, user_agent=None, respect_robots=True):
         """Load the default rules.
 
         Args:
             user_agent (str): The user agent to pass on to the rules.
             respect_robots (bool): Whether to respect the X-Robots-Tag header.
-            respect_spawning (bool): Whether to respect the spawning API.
         """
         super().__init__()
         if respect_robots:
             self.rules.append(XRobotsTagHeader(user_agent))
-        if respect_spawning:
-            self.rules.append(SpawningAPI(user_agent))

--- a/src/datadiligence/evaluators/preprocess.py
+++ b/src/datadiligence/evaluators/preprocess.py
@@ -27,11 +27,12 @@ class PreprocessEvaluator(Evaluator):
         if issubclass(rule.__class__, BulkRule):
             self.rules.append(rule)
 
-    def get_allowed(self, urls=None):
+    def filter_allowed(self, urls=None, **kwargs):
         """Filter a list of urls based on the rules in this evaluator.
 
         Args:
             urls (list): A list of urls to filter.
+            **kwargs: Arbitrary keyword arguments to read args from.
 
         Returns:
             list: A list of urls that are allowed.
@@ -46,9 +47,31 @@ class PreprocessEvaluator(Evaluator):
             if len(allowed) == 0:
                 break
             if rule.is_ready():
-                allowed = rule.get_allowed(urls=allowed)
+                allowed = rule.filter_allowed(urls=allowed)
 
         return allowed
 
-    def is_allowed(self, **kwargs):
-        return self.get_allowed(**kwargs)
+    def is_allowed(self, urls=None, *kwargs):
+        """
+        Check if the urls are allowed.
+
+        Args:
+            urls (list): A list of urls to check.
+            **kwargs: Arbitrary keyword arguments to read args from.
+
+        Returns:
+            bool: List of boolean values, respectively indicating if can be used or not
+        """
+
+        if urls is None:
+            return []
+
+        allowed = [True] * len(urls)
+        for rule in self.rules:
+            if rule.is_ready():
+                rule_results = rule.is_allowed(urls=urls)
+
+                # update allowed list to False only if rule_results is False
+                allowed = [a and b for a, b in zip(allowed, rule_results)]
+
+        return allowed

--- a/src/datadiligence/rules/base.py
+++ b/src/datadiligence/rules/base.py
@@ -23,10 +23,10 @@ class Rule:
 
 class BulkRule(Rule):
     """
-    Base class for bulk rules. get_allowed and is_ready must be implemented.
+    Base class for bulk rules. filter_allowed and is_ready must be implemented.
     """
 
-    def get_allowed(self, **kwargs):
+    def filter_allowed(self, **kwargs):
         """Filter a list of entries based on the rules in this evaluator."""
         raise NotImplementedError
 

--- a/tests/test_bootstrapper.py
+++ b/tests/test_bootstrapper.py
@@ -62,7 +62,7 @@ class BootstrapTests(TestCase):
         dd.load_defaults()
         self.assertTrue(isinstance(dd.get_evaluator("preprocess"), dd.PreprocessEvaluator))
         self.assertTrue(isinstance(dd.get_evaluator("postprocess"), dd.PostprocessEvaluator))
-        self.assertEqual(len(dd.list_evaluators()), 3)
+        self.assertEqual(len(dd.list_evaluators()), 2)
 
     def test_register_evaluator(self):
         custom_evaluator = dd.Evaluator()

--- a/tests/test_spawningapi.py
+++ b/tests/test_spawningapi.py
@@ -87,52 +87,89 @@ class SpawningAPITest(TestCase):
         os.environ[SpawningAPI.API_KEY_ENV_VAR] = os.environ[SpawningAPI.API_KEY_ENV_VAR+"_TMP"]
         del os.environ[SpawningAPI.API_KEY_ENV_VAR+"_TMP"]
 
-    def test_get_allowed(self):
+    def test_filter_allowed(self):
         spawning_api = SpawningAPI(max_concurrent_requests=2000)
         spawning_api.SPAWNING_AI_API_URL = "http://localhost:5001/opts"
-        allowed = spawning_api.get_allowed(urls=self.urls)
+        allowed = spawning_api.filter_allowed(urls=self.urls)
         self.assertEqual(len(allowed), 3)
+        self.assertEqual(allowed[0], self.urls[1])
+        self.assertEqual(allowed[1], self.urls[2])
+        self.assertEqual(allowed[2], self.urls[5])
+
+        allowed = spawning_api.filter_allowed(urls=self.urls)
+        self.assertEqual(len(allowed), 3)
+        self.assertEqual(allowed[0], self.urls[1])
+        self.assertEqual(allowed[1], self.urls[2])
+        self.assertEqual(allowed[2], self.urls[5])
+
+        allowed = spawning_api.filter_allowed(url=self.urls[1])
+        self.assertEqual(allowed[0], self.urls[1])
+
+        with self.assertRaises(datadiligence.exceptions.SpawningNoParam):
+            spawning_api.is_allowed(args=None)
 
     def test_is_allowed(self):
         spawning_api = SpawningAPI()
         spawning_api.SPAWNING_AI_API_URL = "http://localhost:5001/opts"
-        allowed = spawning_api.is_allowed(self.urls[1])
+        allowed = spawning_api.is_allowed(url=self.urls[1])
         self.assertTrue(allowed)
-        allowed = spawning_api.is_allowed(None)
-        self.assertTrue(allowed)
+
+        results = spawning_api.is_allowed(urls=self.urls)
+        self.assertEqual(len(results), 6)
+        self.assertFalse(results[0])
+        self.assertTrue(results[1])
+        self.assertTrue(results[2])
+        self.assertFalse(results[3])
+        self.assertFalse(results[4])
+        self.assertTrue(results[5])
 
     def test_api_exception_handling(self):
         spawning_api = SpawningAPI(user_agent="spawningbot")
         spawning_api.SPAWNING_AI_API_URL = "http://localhost:5001/fail"
-        self.assertRaises(dd.exceptions.SpawningAIAPIError, spawning_api.get_allowed, self.urls)
+        self.assertRaises(dd.exceptions.SpawningAIAPIError, spawning_api.filter_allowed, self.urls)
 
         spawning_api.SPAWNING_AI_API_URL = "http://localhost:5001/fail2"
-        self.assertRaises(dd.exceptions.SpawningAIAPIError, spawning_api.get_allowed, self.urls)
+        self.assertRaises(dd.exceptions.SpawningAIAPIError, spawning_api.filter_allowed, self.urls)
 
         with self.assertRaises(dd.exceptions.SpawningNoParam):
-            spawning_api.get_allowed(arg=None)
+            spawning_api.filter_allowed(arg=None)
 
     def test_api_exception_handling_async(self):
         spawning_api = SpawningAPI()
         spawning_api.SPAWNING_AI_API_URL = "http://localhost:5001/opts"
-        allowed = run_async_in_sync(spawning_api.get_allowed_async, urls=self.urls)
+        allowed = run_async_in_sync(spawning_api.filter_allowed_async, urls=self.urls)
         self.assertEqual(len(allowed), 3)
 
-        allowed = run_async_in_sync(spawning_api.get_allowed_async, url=self.urls[0])
+        allowed = run_async_in_sync(spawning_api.filter_allowed_async, url=self.urls[0])
         self.assertEqual(len(allowed), 3)
+
+        allowed = run_async_in_sync(spawning_api.is_allowed_async, urls=self.urls)
+        self.assertEqual(len(allowed), 6)
+        self.assertFalse(allowed[0])
+        self.assertTrue(allowed[1])
+        self.assertTrue(allowed[2])
+        self.assertFalse(allowed[3])
+        self.assertFalse(allowed[4])
+        self.assertTrue(allowed[5])
+
+        allowed = run_async_in_sync(spawning_api.is_allowed_async, url=self.urls[0])
+        self.assertEqual(len(allowed), 6)
 
     def test_fails_async(self):
         spawning_api = SpawningAPI(user_agent="spawningbot")
         spawning_api.SPAWNING_AI_API_URL = "http://localhost:5001/fail"
         with self.assertRaises(dd.exceptions.SpawningAIAPIError):
-            run_async_in_sync(spawning_api.get_allowed_async, urls=self.urls)
+            run_async_in_sync(spawning_api.filter_allowed_async, urls=self.urls)
 
         spawning_api.SPAWNING_AI_API_URL = "http://localhost:5001/fail2"
         with self.assertRaises(dd.exceptions.SpawningAIAPIError):
-            run_async_in_sync(spawning_api.get_allowed_async, urls=self.urls)
+            run_async_in_sync(spawning_api.filter_allowed_async, urls=self.urls)
 
         with self.assertRaises(dd.exceptions.SpawningNoParam):
-            run_async_in_sync(spawning_api.get_allowed_async, arg=None)
+            run_async_in_sync(spawning_api.filter_allowed_async, arg=None)
+
+        with self.assertRaises(dd.exceptions.SpawningNoParam):
+            run_async_in_sync(spawning_api.is_allowed_async, arg=None)
 
     @classmethod
     def tearDownClass(cls):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 minversion = 3.24
-envlist = py36,py37,py38,py39,py310,py311
+envlist = py37,py38,py39,py310,py311
 isolated_build = True
 
 


### PR DESCRIPTION
Added function `filter_allowed` to bulk rules and evaluators. This function should remove elements from the provided list and return only approved elements. Additionally, the bulk rules and evaluators `is_allowed` function has been updated to instead return a list of boolean values. Each boolean value indicates if each respective element is allowed to be used or not (opted out). 

Also removed the default http evaluator from bootstrapping logic, as it's largely redundant with the existing bootstrapped evaluators.